### PR TITLE
Add support for ENV settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # User-specific stuff:
-.idea/*
+.idea
 
 ## File-based project format:
 *.iws
@@ -11,6 +11,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pyc
 
 # logs
 *.log*
@@ -24,3 +25,6 @@ __pycache__/
 
 # generators
 *.bat
+
+# Pyenv
+**/.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==0.11.1
-psutil==5.2.2
-requests==2.10.0
+Flask ~= 0.12.2
+psutil ~= 5.4.0
+requests ~= 2.18.4

--- a/scan.py
+++ b/scan.py
@@ -27,7 +27,15 @@ consoleHandler.setLevel(logging.DEBUG)
 consoleHandler.setFormatter(logFormatter)
 rootLogger.addHandler(consoleHandler)
 
-fileHandler = RotatingFileHandler(utils.get_logfile_path(), maxBytes=1024 * 1024 * 5, backupCount=5)
+fileHandler = RotatingFileHandler(
+    config.get_setting(
+        '--logfile',
+        'PLEX_AUTOSCAN_LOGFILE',
+        os.path.join(os.path.dirname(sys.argv[0]), 'plex_autoscan.log')
+    ),
+    maxBytes=1024 * 1024 * 5,
+    backupCount=5
+)
 fileHandler.setLevel(logging.DEBUG)
 fileHandler.setFormatter(logFormatter)
 rootLogger.addHandler(fileHandler)
@@ -39,16 +47,12 @@ logger.setLevel(logging.DEBUG)
 scan_lock = Lock()
 
 # Config
-docker = False
-for item in sys.argv:
-    if item == 'docker':
-        docker = True
-config = config.load(docker)
-
+config = config.load()
 
 ############################################################
 # FUNCS
 ############################################################
+
 
 def start_scan(path, scan_for, scan_type):
     section = utils.get_plex_section(config, path)

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,6 @@
 import logging
-import os
 import subprocess
-import sys
 import time
-
 import psutil
 
 logger = logging.getLogger("UTILS")
@@ -44,7 +41,8 @@ def is_process_running(process_name):
                 return True, process
 
         return False, None
-    except:
+
+    except Exception:
         logger.exception("Exception checking for process: '%s': ", process_name)
         return False, None
 
@@ -57,26 +55,13 @@ def wait_running_process(process_name):
                          process.pid, process.cmdline())
             time.sleep(60)
             running, process = is_process_running(process_name)
+
         return True
-    except:
+
+    except Exception:
         logger.exception("Exception waiting for process: '%s'", process_name())
+
         return False
-
-
-def get_logfile_path():
-    pos = 0
-    log_path = os.path.join(os.path.dirname(sys.argv[0]), 'plex_autoscan.log')
-
-    try:
-        for item in sys.argv:
-            if item == '--logfile':
-                log_path = sys.argv[pos + 1]
-                break
-            pos += 1
-    except:
-        logger.exception("Exception retrieving supplied logfile: ")
-
-    return log_path
 
 
 def run_command(command):
@@ -96,4 +81,5 @@ def should_ignore(file_path, config):
     for item in config['SERVER_IGNORE_LIST']:
         if item.lower() in file_path.lower():
             return True, item
+
     return False, None


### PR DESCRIPTION
- Allows override of any config setting by an environment variable with the same name
  - Example: `PLEX_TOKEN=12345 python scan.py`
- Adds ENV support for config and log file location
  - `--logfile` || `PLEX_AUTOSCAN_LOGFILE`
  - `--config` || `PLEX_AUTOSCAN_CONFIG`
- Some minor code fixes/enhancements

Command line arguments get priority over environment variables.