### PR TITLE
Improve argument parsing

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,8 +73,8 @@ def upgrade(config_path, cfg):
 
     # Only rewrite config file if new fields added
     if len(fields):
-        build(cfg)
-        logger.info("Upgraded config, added %d new field(s): %r", len(fields), fields)
+        logger.warn("Upgraded config, added %d new field(s): %r", len(fields), fields)
+        build(config_path, cfg)
 
     # Update in-memory config with environment settings
     cfg.update(fields_env)

--- a/config.py
+++ b/config.py
@@ -3,9 +3,10 @@ import logging
 import os
 import sys
 import uuid
+import argparse
+
 
 logger = logging.getLogger("CONFIG")
-logger.setLevel(logging.DEBUG)
 
 base_config = {
     'PLEX_USER': 'plex',
@@ -57,6 +58,23 @@ base_config = {
     'USE_SUDO': True
 }
 
+settings = {
+    'config': {
+        'argv': '--config',
+        'env': 'PLEX_AUTOSCAN_CONFIG',
+        'default': os.path.join(os.path.dirname(sys.argv[0]), 'config', 'config.json')
+    },
+    'logfile': {
+        'argv': '--logfile',
+        'env': 'PLEX_AUTOSCAN_LOGFILE',
+        'default': os.path.join(os.path.dirname(sys.argv[0]), 'plex_autoscan.log')
+    },
+    'loglevel': {
+        'argv': '--loglevel',
+        'env': 'PLEX_AUTOSCAN_LOGLEVEL',
+        'default': 'INFO'
+    }
+}
 
 def upgrade(config_path, cfg):
     fields = []
@@ -82,15 +100,11 @@ def upgrade(config_path, cfg):
     return cfg
 
 
-def load():
-    config_path = get_setting(
-        '--config',
-        'PLEX_AUTOSCAN_CONFIG',
-        os.path.join(os.path.dirname(sys.argv[0]), 'config', 'config.json')
-    )
+def load(cmd_args):
+    config_path = get_setting(cmd_args, 'config')
 
     if not os.path.exists(config_path):
-        logger.info("No config file found, creating default config.")
+        logger.warn("No config file found, creating default config.")
         build(config_path)
 
     cfg = {}
@@ -104,26 +118,78 @@ def build(config_path, cfg=base_config):
     with open(config_path, 'w') as fp:
         json.dump(cfg, fp, indent=4, sort_keys=True)
 
-    logger.info("Please configure/review config before running again: %r", config_path)
+    logger.warn("Please configure/review config before running again: %r", config_path)
 
     exit(0)
 
 
-def get_setting(argv_name, env_name, argv_default):
+def get_setting(args, name):
     try:
-        # Argrument priority: cmd < environment < default
-        if argv_name in sys.argv:
-            argv_value = sys.argv[sys.argv.index(argv_name) + 1]
+        argv_value = None
 
-        elif env_name in os.environ:
-            argv_value = os.environ[env_name]
+        # Argrument priority: cmd < environment < default
+        if args[name]:
+            argv_value = args[name]
+            logger.info("Using ARG setting %s=%s", name, argv_value)
+
+        elif settings[name]['env'] in os.environ:
+            argv_value = os.environ[settings[name]['env']]
+            logger.info("Using ENV setting %s=%s", settings[name]['env'], argv_value)
 
         else:
-            argv_value = argv_default
-
-        logger.debug("Using ARG setting %s=%s", env_name, argv_value)
+            argv_value = settings[name]['default']
+            logger.info("Using default setting %s=%s", settings[name]['argv'], argv_value)
 
     except Exception:
-        logger.exception("Exception retrieving argument value: %r" % argv_name)
+        logger.exception("Exception retrieving setting value: %r" % name)
 
     return argv_value
+
+
+# Parse command line arguments
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Script to assist sonarr/radarr with plex imports. Will only scan the folder \n'
+            'that has been imported, instead of the whole library section.'
+        ),
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    # Mode
+    parser.add_argument('cmd',
+        choices=('sections', 'server'),
+        help=(
+            '"sections": prints plex sections\n'
+            '"server": starts the application'
+        )
+    )
+
+    # Config file
+    parser.add_argument(settings['config']['argv'],
+        nargs='?',
+        const=None,
+        help='Config file location (default: %s)' % settings['config']['default']
+    )
+
+    # Log file
+    parser.add_argument(settings['logfile']['argv'],
+        nargs='?',
+        const=None,
+        help='Log file location (default: %s)' % settings['logfile']['default']
+    )
+
+    # Logging level
+    parser.add_argument(settings['loglevel']['argv'],
+        choices=('WARN', 'INFO', 'DEBUG'),
+        help='Log level (default: %s)' % settings['loglevel']['default']
+    )
+
+    # Print help by default if no arguments
+    if len(sys.argv) == 1:
+        parser.print_help()
+
+        sys.exit(0)
+
+    else:
+        return vars(parser.parse_args())

--- a/plex.py
+++ b/plex.py
@@ -7,12 +7,11 @@ try:
     from shlex import quote as cmd_quote
 except ImportError:
     from pipes import quote as cmd_quote
-import requests
 
+import requests
 import utils
 
 logger = logging.getLogger("PLEX")
-logger.setLevel(logging.DEBUG)
 
 
 def scan(config, lock, path, scan_for, section, scan_type):

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,6 @@ import time
 import psutil
 
 logger = logging.getLogger("UTILS")
-logger.setLevel(logging.DEBUG)
 
 
 def get_plex_section(config, path):


### PR DESCRIPTION
- Use argparse for parsing command line options
- Allow logging level to be defined
  - Use INFO by default
  - Child loggers inherit level from root
  - Add ENV variable support
- Print help if not args specified

```
usage: scan.py [-h] [--config [CONFIG]] [--logfile [LOGFILE]]
               [--loglevel {WARN,INFO,DEBUG}]
               {sections,server}

Script to assist sonarr/radarr with plex imports. Will only scan the folder 
that has been imported, instead of the whole library section.

positional arguments:
  {sections,server}     "sections": prints plex sections
                        "server": starts the application

optional arguments:
  -h, --help            show this help message and exit
  --config [CONFIG]     Config file location (default: config/config.json)
  --logfile [LOGFILE]   Log file location (default: plex_autoscan.log)
  --loglevel {WARN,INFO,DEBUG}
                        Log level (default: INFO)
```
