### PR TITLE
Add variable RUN_COMMAND_AFTER_SCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ _Note: Changes to config file require a restart of the Plex Autoscan service: `s
     "RC_URL": "http://localhost:5572"
   },
   "RUN_COMMAND_BEFORE_SCAN": "",
+  "RUN_COMMAND_AFTER_SCAN": "",
   "SERVER_ALLOW_MANUAL_SCAN": false,
   "SERVER_FILE_EXIST_PATH_MAPPINGS": {
       "/mnt/unionfs/media": [
@@ -570,6 +571,8 @@ The `180` seconds in the example above are from the `SERVER_SCAN_DELAY`, if any 
 ### Misc
 
 ```json
+"RUN_COMMAND_BEFORE_SCAN": "",
+"RUN_COMMAND_AFTER_SCAN": "",
 "SERVER_ALLOW_MANUAL_SCAN": false,
 "SERVER_IGNORE_LIST": [
   "/.grab/",
@@ -586,6 +589,10 @@ The `180` seconds in the example above are from the `SERVER_SCAN_DELAY`, if any 
 },
 ```
 
+
+`RUN_COMMAND_BEFORE_SCAN` - If a command is supplied, it is executed before the Plex Media Scanner command.
+
+`RUN_COMMAND_AFTER_SCAN` - If a command is supplied, it is executed after the Plex Media Scanner, Empty Trash and Analyze commands.
 
 `SERVER_ALLOW_MANUAL_SCAN` - When enabled, allows GET requests to the webhook URL to allow manual scans on a specific filepath. Default is `false`.
 

--- a/config.py
+++ b/config.py
@@ -60,6 +60,7 @@ class Config(object):
         },
         'DOCKER_NAME': 'plex',
         'RUN_COMMAND_BEFORE_SCAN': '',
+        'RUN_COMMAND_AFTER_SCAN': '',
         'USE_DOCKER': False,
         'USE_SUDO': True,
         'GDRIVE': {

--- a/plex.py
+++ b/plex.py
@@ -128,7 +128,7 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
             else:
                 logger.info("No '%s' processes were found.", scanner_name)
 
-        # run external command if supplied
+        # run external command before scan if supplied
         if len(config['RUN_COMMAND_BEFORE_SCAN']) > 2:
             logger.info("Running external command: %r", config['RUN_COMMAND_BEFORE_SCAN'])
             utils.run_command(config['RUN_COMMAND_BEFORE_SCAN'])
@@ -172,6 +172,12 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
             logger.debug("Sleeping 10 seconds before sending analyze request")
             time.sleep(10)
             analyze_item(config, path)
+
+        # run external command after scan if supplied
+        if len(config['RUN_COMMAND_AFTER_SCAN']) > 2:
+            logger.info("Running external command: %r", config['RUN_COMMAND_AFTER_SCAN'])
+            utils.run_command(config['RUN_COMMAND_AFTER_SCAN'])
+            logger.info("Finished running external command")
 
     except Exception:
         logger.exception("Unexpected exception occurred while processing: '%s'", scan_path)


### PR DESCRIPTION
Useful addition in my opinion. My use case: execute a SQLite command after the scan to change the timestamp(s) of the file(s) just added to the PMS database.