### PR TITLE
Docker: Wait for Plex Scanners for matching DOCKER_NAME container only when USE_DOCKER is enabled.

### DIFF
--- a/plex.py
+++ b/plex.py
@@ -135,7 +135,7 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
         # wait for existing scanners being ran by plex
         if config['PLEX_WAIT_FOR_EXTERNAL_SCANNERS']:
             scanner_name = os.path.basename(config['PLEX_SCANNER']).replace('\\', '')
-            if not utils.wait_running_process(scanner_name):
+            if not utils.wait_running_process(scanner_name, config['USE_DOCKER'], cmd_quote(config['DOCKER_NAME'])):
                 logger.warning(
                     "There was a problem waiting for existing '%s' process(s) to finish, aborting scan.", scanner_name)
                 # remove item from database if sqlite is enabled

--- a/utils.py
+++ b/utils.py
@@ -118,7 +118,7 @@ def run_command(command, get_output=False):
                 get_output += output
 
     rc = process.poll()
-    return rc if not get_output else get_output
+    return rc if get_output else get_output
 
 
 def should_ignore(file_path, config):

--- a/utils.py
+++ b/utils.py
@@ -110,7 +110,7 @@ def run_command(command, get_output=False):
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     while True:
         output = str(process.stdout.readline()).lstrip('b').replace('\\n', '').strip()
-        if output and len(output) >= 8:
+        if output and len(output) >= 3:
             if not get_output:
                 logger.info(output)
             else:

--- a/utils.py
+++ b/utils.py
@@ -106,7 +106,7 @@ def wait_running_process(process_name, use_docker=False, plex_container=None):
 
 
 def run_command(command, get_output=False):
-    output = ''
+    total_output = ''
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     while True:
         output = str(process.stdout.readline()).lstrip('b').replace('\\n', '').strip()
@@ -116,10 +116,10 @@ def run_command(command, get_output=False):
             if not get_output:
                 logger.info(output)
             else:
-                output += output
+                total_output += output
 
     rc = process.poll()
-    return rc if not get_output else output
+    return rc if not get_output else total_output
 
 
 def should_ignore(file_path, config):

--- a/utils.py
+++ b/utils.py
@@ -67,6 +67,7 @@ def is_process_running(process_name, plex_container=None):
                 get_pid_container = "docker inspect --format '{{.Name}}' \"$(cat /proc/%s/cgroup |head -n 1 " \
                                     "|cut -d / -f 3)\" | sed 's/^\///'" % process.pid
                 process_container = run_command(get_pid_container, True)
+                logger.debug("Using: %s", get_pid_container)
                 logger.debug("Docker Container For PID %s: %s", process.pid,
                              process_container.strip() if process_container is not None else 'Unknown???')
                 if process_container is not None and isinstance(process_container, str) and \

--- a/utils.py
+++ b/utils.py
@@ -111,8 +111,9 @@ def run_command(command, get_output=False):
     while True:
         output = str(process.stdout.readline()).lstrip('b').replace('\\n', '').strip()
         if output and len(output) >= 3:
-            if not get_output and len(output) >= 8:
-                logger.info(output)
+            if not get_output:
+                if len(output) >= 8:
+                    logger.info(output)
             else:
                 total_output += output
 

--- a/utils.py
+++ b/utils.py
@@ -68,7 +68,7 @@ def is_process_running(process_name, plex_container=None):
                                     "|cut -d / -f 3)\" | sed 's/^\///'" % process.pid
                 process_container = run_command(get_pid_container, True)
                 logger.debug("Using: %s", get_pid_container)
-                logger.debug("Docker Container For PID %s: %s", process.pid,
+                logger.debug("Docker Container For PID %s: %r", process.pid,
                              process_container.strip() if process_container is not None else 'Unknown???')
                 if process_container is not None and isinstance(process_container, str) and \
                         process_container.strip().lower() == plex_container.lower():

--- a/utils.py
+++ b/utils.py
@@ -115,10 +115,10 @@ def run_command(command, get_output=False):
             if not get_output:
                 logger.info(output)
             else:
-                get_output += output
+                output += output
 
     rc = process.poll()
-    return rc if get_output else get_output
+    return rc if not get_output else output
 
 
 def should_ignore(file_path, config):

--- a/utils.py
+++ b/utils.py
@@ -110,13 +110,14 @@ def run_command(command, get_output=False):
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     while True:
         output = str(process.stdout.readline()).lstrip('b').replace('\\n', '').strip()
-        if process.poll() is not None:
-            break
         if output and len(output) >= 8:
             if not get_output:
                 logger.info(output)
             else:
                 total_output += output
+
+        if process.poll() is not None:
+            break
 
     rc = process.poll()
     return rc if not get_output else total_output

--- a/utils.py
+++ b/utils.py
@@ -111,7 +111,7 @@ def run_command(command, get_output=False):
     while True:
         output = str(process.stdout.readline()).lstrip('b').replace('\\n', '').strip()
         if output and len(output) >= 3:
-            if not get_output:
+            if not get_output and len(output) >= 8:
                 logger.info(output)
             else:
                 total_output += output


### PR DESCRIPTION
If `PLEX_WAIT_EXTERNAL_SCANNERS` is enabled, and `USE_DOCKER` is also enabled.

It will only wait for scanners from the `DOCKER_NAME` container.

Wish: https://beerpay.io/l3uddz/plex_autoscan/wishes/5c7c84c7996baf17b9931f89