### PR TITLE
Ported module imports to Python3 equivalents, cleared up a whitespace warning.

### DIFF
--- a/config.py
+++ b/config.py
@@ -249,7 +249,7 @@ class Config(object):
     def save(self, cfg,exitOnSave=True):
         with open(self.settings['config'], 'w') as fp:
             json.dump(cfg, fp, indent=2, sort_keys=True)
-	if exitOnSave:
+        if exitOnSave:
              logger.warn(
                  "Please configure/review config before running again: %r",
                  self.settings['config']

--- a/gdrive.py
+++ b/gdrive.py
@@ -1,7 +1,12 @@
 import json
 import logging
 import os
-from urllib.parse import urlencode
+try:
+    # try the Python2 version
+    from urllib import urlencode
+except ImportError:
+    # fallback to the Python3 version
+    from urllib.parse import urlencode
 
 import backoff
 import requests

--- a/gdrive.py
+++ b/gdrive.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from urllib import urlencode
+from urllib.parse import urlencode
 
 import backoff
 import requests

--- a/scan.py
+++ b/scan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 import json
 import logging
 import os

--- a/threads.py
+++ b/threads.py
@@ -1,4 +1,9 @@
-import queue
+try:
+    # try the Python2 version
+    import Queue as queue
+except ImportError:
+    # fallback to the Python3 version
+    import queue as queue
 import copy
 import threading
 

--- a/threads.py
+++ b/threads.py
@@ -1,4 +1,4 @@
-import Queue
+import queue
 import copy
 import threading
 
@@ -7,7 +7,7 @@ class PriorityLock:
     def __init__(self):
         self._is_available = True
         self._mutex = threading.Lock()
-        self._waiter_queue = Queue.PriorityQueue()
+        self._waiter_queue = queue.PriorityQueue()
 
     def acquire(self, priority=0):
         self._mutex.acquire()
@@ -28,7 +28,7 @@ class PriorityLock:
         # Notify the next thread in line, if any.
         try:
             _, event = self._waiter_queue.get_nowait()
-        except Queue.Empty:
+        except queue.Empty:
             self._is_available = True
         else:
             event.set()


### PR DESCRIPTION
I've packaged this service into a Docker container based on Arch Linux, sabrsorensen/arch-plex_autoscan. The Arch Linux package for python2-pip hasn't been updated to handle the changes to the helpers libraries in python2-progress, so installing python2-pip when building my container will fail. To address this, I made some minor changes to update to the Python3 equivalent modules and cleared up a tab vs space warning I received when trying to launch under Python3.