### PR TITLE
fix/scan on server side rename

### DIFF
--- a/google/drive.py
+++ b/google/drive.py
@@ -609,12 +609,19 @@ class GoogleDrive:
                             else:
                                 added_file_paths[change['fileId']] = item_paths
                         else:
-                            logger.debug("Ignoring %r because the md5Checksum was the same as cache: %s", item_paths,
-                                         existing_cache_item['md5Checksum'])
-                            if change['fileId'] in ignored_file_paths:
-                                ignored_file_paths[change['fileId']].extend(item_paths)
+                            if change['file']['name'] == existing_cache_item['name']:
+                                logger.debug("md5Checksum matches but file was server-side renamed: %s", item_paths)
+                                if change['fileId'] in added_file_paths:
+                                    added_file_paths[change['fileId']].extend(item_paths)
+                                else:
+                                    added_file_paths[change['fileId']] = item_paths
                             else:
-                                ignored_file_paths[change['fileId']] = item_paths
+                                logger.debug("Ignoring %r because the md5Checksum was the same as cache: %s", item_paths,
+                                             existing_cache_item['md5Checksum'])
+                                if change['fileId'] in ignored_file_paths:
+                                    ignored_file_paths[change['fileId']].extend(item_paths)
+                                else:
+                                    ignored_file_paths[change['fileId']] = item_paths
                     else:
                         logger.error("No md5Checksum for cache item:\n%s", existing_cache_item)
 


### PR DESCRIPTION
Addition to Google Drive Monitoring enabling re-scan when files in cache match md5checksum but are detected as renamed. Currently, when files were server-side renamed md5Checksum matches and they would be 'ignored' assuming no change causing plex to show as "unavailable".