### PR TITLE
Add PLEX_SECTION_MAPPINGS_WITH_API to map Section root paths with API instead of sqlite database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ Sample output:
   2: TV
 ```
 
+`PLEX_SECTION_PATH_MAPPINGS_WITH_API` - Use the Plex Server's API to obtain Section Paths instead of querying the sqlite database directly. Default is `false`.
+
 ### Plex Emptying Trash
 
 When media is upgraded by Sonarr/Radarr/Lidarr, the previous files are then deleted. When Plex gets the scan request after the upgrade, the new media is added in to the library, but the previous media files would still be listed there but labeled as "unavailable".

--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ class Config(object):
         'PLEX_FIX_MISMATCHED_LANG': 'en',
         'PLEX_TOKEN': '',
         'PLEX_CHECK_BEFORE_SCAN': False,
+        'PLEX_SECTION_PATH_MAPPING_WITH_API': False,
         'SERVER_IP': '0.0.0.0',
         'SERVER_PORT': 3467,
         'SERVER_PASS': uuid.uuid4().hex,

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ class Config(object):
         'PLEX_FIX_MISMATCHED_LANG': 'en',
         'PLEX_TOKEN': '',
         'PLEX_CHECK_BEFORE_SCAN': False,
-        'PLEX_SECTION_PATH_MAPPING_WITH_API': False,
+        'PLEX_SECTION_PATH_MAPPINGS_WITH_API': False,
         'SERVER_IP': '0.0.0.0',
         'SERVER_PORT': 3467,
         'SERVER_PASS': uuid.uuid4().hex,

--- a/plex.py
+++ b/plex.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sqlite3
 import time
-import config
 from contextlib import closing
 
 import db
@@ -35,7 +34,6 @@ def get_detailed_sections_info(conf):
           plexsections = []
           for document in root.findall("Directory"):
               for k in document.findall("Location"):
-                  #pathz.append([document.get('key'), os.path.join(k.get('path'), '')])
                   pathz.setdefault(document.get('key'), []).append(os.path.join(k.get('path'), ''))
                   sectionz[document.get('key')] = document.get('title')
 
@@ -44,11 +42,6 @@ def get_detailed_sections_info(conf):
           return plexsections
     except Exception as e:
         logger.exception("Issue encountered when attempting to list detailed sections info.")
-
-#conf = config.Config()
-#conf.load()
-
-#print(get_detailed_sections_info(conf))
 
 def show_detailed_sections_info(conf):
     plexsections = get_detailed_sections_info(conf)

--- a/plex.py
+++ b/plex.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sqlite3
 import time
+import config
 from contextlib import closing
 
 import db
@@ -16,28 +17,49 @@ import utils
 
 logger = logging.getLogger("PLEX")
 
+from collections import namedtuple
+PlexSection = namedtuple("PlexSection", "id title paths")
 
-def show_detailed_sections_info(conf):
+def get_detailed_sections_info(conf):
     from xml.etree import ElementTree
     try:
         logger.info("Requesting section info from Plex...")
         resp = requests.get('%s/library/sections/all?X-Plex-Token=%s' % (
             conf.configs['PLEX_LOCAL_URL'], conf.configs['PLEX_TOKEN']), timeout=30)
         if resp.status_code == 200:
-            logger.info("Requesting of section info was successful.")
-            logger.debug("Request response: %s", resp.text)
-            root = ElementTree.fromstring(resp.text)
-            print('')
-            print("Plex Sections:")
-            print("==============")
-            for document in root.findall("Directory"):
-                print('')
-                print(document.get('key') + ') ' + document.get('title'))
-                dashes_length = len(document.get('key') + ') ' + document.get('title'))
-                print('-' * dashes_length)
-                print("\n".join([os.path.join(k.get('path'), '') for k in document.findall("Location")]))
+          logger.info("Requesting of section info was successful.")
+          logger.debug("Request response: %s", resp.text)
+          root = ElementTree.fromstring(resp.text)
+          pathz = {}
+          sectionz = {}
+          plexsections = []
+          for document in root.findall("Directory"):
+              for k in document.findall("Location"):
+                  #pathz.append([document.get('key'), os.path.join(k.get('path'), '')])
+                  pathz.setdefault(document.get('key'), []).append(os.path.join(k.get('path'), ''))
+                  sectionz[document.get('key')] = document.get('title')
+
+          for key in sorted(sectionz):
+              plexsections.append(PlexSection(key, sectionz[key], pathz[key]))
+          return plexsections
     except Exception as e:
         logger.exception("Issue encountered when attempting to list detailed sections info.")
+
+#conf = config.Config()
+#conf.load()
+
+#print(get_detailed_sections_info(conf))
+
+def show_detailed_sections_info(conf):
+    plexsections = get_detailed_sections_info(conf)
+    print('')
+    print("Plex Sections:")
+    print("==============")
+    for section in plexsections:
+        print('')
+        print(section.id + ') ' + section.title)
+        print('-' * len(section.id + ') ' + section.title))
+        print("\n".join(section.paths))
 
 
 def scan(config, lock, path, scan_for, section, scan_type, resleep_paths, scan_title=None, scan_lookup_type=None,

--- a/scan.py
+++ b/scan.py
@@ -113,7 +113,7 @@ def queue_processor():
 
 
 def start_scan(path, scan_for, scan_type, scan_title=None, scan_lookup_type=None, scan_lookup_id=None):
-    section = utils.get_plex_section(conf.configs, path)
+    section = utils.get_plex_section(conf, path)
     if section <= 0:
         return False
     else:

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,7 @@ from contextlib import closing
 from copy import copy
 
 import requests
+import plex
 
 try:
     from urlparse import urljoin
@@ -19,26 +20,36 @@ import psutil
 
 logger = logging.getLogger("UTILS")
 
+def get_plex_section(conf, path):
+    if conf.configs['PLEX_SECTION_PATH_MAPPINGS_WITH_API']:
+        logger.debug("Using API to obtain section paths")
+        plexsections = plex.get_detailed_sections_info(conf)
+        for section in plexsections:
+            for root_path in section.paths:
+                if path.startswith(root_path):
+                    logger.debug("Plex Library Section ID '%s' matching root folder '%s' was found in the Plex DB.",
+                                  section.id, root_path)
+                    return int(section.id)
+        logger.error("Unable to map '%s' to a Section ID.", path)
+    else:
+        try:
+            with sqlite3.connect(conf.configs['PLEX_DATABASE_PATH']) as conn:
+                conn.row_factory = sqlite3.Row
+                conn.text_factory = str
+                with closing(conn.cursor()) as c:
+                    # check if file exists in plex
+                    logger.debug("Checking if root folder path '%s' matches Plex Library root path in the Plex DB.", path)
+                    section_data = c.execute("SELECT library_section_id,root_path FROM section_locations").fetchall()
+                    for section_id, root_path in section_data:
+                        if path.startswith(root_path + os.sep):
+                            logger.debug("Plex Library Section ID '%d' matching root folder '%s' was found in the Plex DB.",
+                                         section_id, root_path)
+                            return int(section_id)
+                    logger.error("Unable to map '%s' to a Section ID.", path)
 
-def get_plex_section(config, path):
-    try:
-        with sqlite3.connect(config['PLEX_DATABASE_PATH']) as conn:
-            conn.row_factory = sqlite3.Row
-            conn.text_factory = str
-            with closing(conn.cursor()) as c:
-                # check if file exists in plex
-                logger.debug("Checking if root folder path '%s' matches Plex Library root path in the Plex DB.", path)
-                section_data = c.execute("SELECT library_section_id,root_path FROM section_locations").fetchall()
-                for section_id, root_path in section_data:
-                    if path.startswith(root_path + os.sep):
-                        logger.debug("Plex Library Section ID '%d' matching root folder '%s' was found in the Plex DB.",
-                                     section_id, root_path)
-                        return int(section_id)
-                logger.error("Unable to map '%s' to a Section ID.", path)
-
-    except Exception:
-        logger.exception("Exception while trying to map '%s' to a Section ID in the Plex DB: ", path)
-    return -1
+        except Exception:
+            logger.exception("Exception while trying to map '%s' to a Section ID in the Plex DB: ", path)
+        return -1
 
 def map_pushed_path(config, path):
     for mapped_path, mappings in config['SERVER_PATH_MAPPINGS'].items():


### PR DESCRIPTION
Hi,

Thank you so much for this project and all other work you have done.
For some reason my plex database lacks a lot of the information this script tends to rely on (most tables in my db are empty).

Things I noticed that don't work on my server:
 - `PLEX_ANALYZE_TYPE`  (because media_parts table is empty)
 - `PLEX_FIX_MISMATCHED` (because media_parts table is empty)
 - `get_plex_section` Method for the automatic Section ID mapping (section* tables are also empty).

This PR introduces the config option `PLEX_SECTION_MAPPINGS_WITH_API`.
When this is set to `true`, the PlexServer API will be used to obtain root paths. Based on the "sections+" command.

By setting `PLEX_ANALYZE_TYPE `to `off`, PLEX_FIX_MISMATCHED to `false` and `PLEX_SECTION_MAPPINGS_WITH_API` to `true` the script works with my bugged/empty plex database.

Hopefully it helps others.